### PR TITLE
fix: apply font to body not *

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SUIT―수트는 반복되는 노력을 기울이지 않아도 완성도 높은 
 <link href="https://cdn.jsdelivr.net/gh/sunn-us/SUIT/fonts/static/woff2/SUIT.css" rel="stylesheet">
 
 <style>
-    * {font-family: 'SUIT', sans-serif;}
+  body { font-family: 'SUIT', sans-serif; }
 </style>
 ```
 
@@ -30,7 +30,7 @@ SUIT―수트는 반복되는 노력을 기울이지 않아도 완성도 높은 
 <link href="https://cdn.jsdelivr.net/gh/sunn-us/SUIT/fonts/variable/woff2/SUIT-Variable.css" rel="stylesheet">
 
 <style>
-    * {font-family: 'SUIT Variable', sans-serif;}
+  body { font-family: 'SUIT Variable', sans-serif; }
 </style>
 ```
 


### PR DESCRIPTION
```css
* { font-family: 'SUIT', sans-serif; }
```

위와 같이 설정할 경우 다음 경우에도 SUIT 글꼴이 사용됩니다.

- `<code>`나 `<pre>`와 같이 고정폭 글꼴이 사용돼야 하는 경우
- `<svg>` 안에 `font-family`를 별도로 지정한 경우 (무시됨)

---

다음 환경에서 확인했습니다.

- Chrome 110.0.5481.177 (arm64)
- Firefox 110.0.1 (64-비트)
- Safari 16.3(18614.4.6.1.6)

---

이에 따라 다음과 같이 수정할 것을 제안합니다.

```css
body { font-family: 'SUIT', sans-serif; }
```